### PR TITLE
fix(parser): remove unused strip export

### DIFF
--- a/src/parsers/__init__.py
+++ b/src/parsers/__init__.py
@@ -1,10 +1,10 @@
 """
 Parsers and converters used by the migration pipeline.
 
-Currently this subpackage exposes ``convert_html_to_ricos`` and
-``strip_html_nodes`` from :mod:`src.parsers.ricos_parser`.
+This subpackage currently exposes :func:`convert_html_to_ricos` from
+``src.parsers.ricos_parser``.
 """
 
 from .ricos_parser import convert_html_to_ricos
 
-__all__ = ["convert_html_to_ricos", "strip_html_nodes"]
+__all__ = ["convert_html_to_ricos"]


### PR DESCRIPTION
## Summary
- clean up parser package export by removing nonexistent `strip_html_nodes`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gemini_client')*
- `pip install gemini-client` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1c7b80c8832994b567d9299a552a