### PR TITLE
Add migration tool pipeline test and fix WixPost slug

### DIFF
--- a/models/wix_post.py
+++ b/models/wix_post.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 def _slugify(value: str) -> str:
@@ -90,6 +90,12 @@ class WixPost(BaseModel):
                 seen.add(item)
                 deduped.append(item)
         return deduped
+
+    @model_validator(mode="after")
+    def _post_init(self) -> "WixPost":
+        if not self.slug and isinstance(self.title, str):
+            self.slug = _slugify(self.title)
+        return self
 
     def to_wix_draft_payload(self, publish: Optional[bool] = None) -> dict[str, Any]:
         body: dict[str, Any] = {

--- a/testes/test_gemini_client.py
+++ b/testes/test_gemini_client.py
@@ -1,36 +1,19 @@
-#!/usr/bin/env python3
-"""Tests for Gemini client.
-
-This module exercises the ``GeminiClient`` when available.  If the
-client cannot be imported (e.g., optional dependency missing), the
-entire test module is skipped.
-"""
-
-import sys
-from pathlib import Path
 import os
-import io
-from PIL import Image
-
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent / "services"))
-
-pytest.importorskip("google.genai")
-
-try:  # pragma: no cover - optional dependency
-    from services.agente_ia.gemini_client import GeminiClient
-except Exception:  # Module not available, skip tests
-    pytest.skip("gemini_client not available", allow_module_level=True)
+from PIL import Image
+from services.agente_ia.gemini_client import GeminiClient
+import io
 
 
 def test_text_only():
+    """Testa a geração de conteúdo somente de texto."""
     client = GeminiClient()
     response = client.generate(["Escreva uma frase criativa sobre inteligência artificial."])
-    assert isinstance(response.get("text"), str)
+    assert isinstance(response.get("text"), str), "A resposta deve conter um texto gerado."
 
 
 def test_text_and_image():
+    """Testa a geração de conteúdo com imagem e texto."""
     img = Image.new("RGB", (10, 10), color="red")
     img_bytes = io.BytesIO()
     img.save(img_bytes, format="PNG")
@@ -38,17 +21,65 @@ def test_text_and_image():
 
     client = GeminiClient()
     response = client.generate(["O que tem nesta imagem?", img_bytes])
-    assert isinstance(response.get("text"), str)
+    assert isinstance(response.get("text"), str), "A resposta deve conter texto gerado a partir da imagem."
 
 
 def test_streaming():
+    """Testa a geração de conteúdo em streaming, verificando a resposta em chunks."""
     client = GeminiClient()
     chunks = list(client.generate_stream(["Conte uma história curta sobre um robô aprendendo a cozinhar."]))
-    assert chunks  # Should yield at least one chunk
+    assert chunks, "O streaming deve gerar ao menos um chunk de texto."
 
 
 def test_init_without_api_key(monkeypatch):
-    """Deve falhar se a chave da API não estiver configurada."""
+    """Testa se a inicialização falha quando a chave da API não está configurada."""
     monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
     with pytest.raises(ValueError):
         GeminiClient()
+
+
+def test_invalid_image_format():
+    """Testa se um erro ocorre ao fornecer uma imagem em formato inválido."""
+    img = b"not an image"  # Dados binários inválidos
+
+    client = GeminiClient()
+    with pytest.raises(Exception):
+        client.generate(["Teste com imagem inválida", img])
+
+
+def test_api_key_not_set(monkeypatch):
+    """Testa se a ausência da chave da API causa uma falha adequada."""
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="Defina a variável de ambiente GOOGLE_API_KEY"):
+        GeminiClient()
+
+
+def test_generate_multiple_inputs():
+    """Testa a geração de conteúdo a partir de múltiplas entradas (texto e imagem)."""
+    img = Image.new("RGB", (10, 10), color="blue")
+    img_bytes = io.BytesIO()
+    img.save(img_bytes, format="PNG")
+    img_bytes = img_bytes.getvalue()
+
+    client = GeminiClient()
+    response = client.generate([
+        "Descreva a imagem abaixo.",
+        img_bytes,
+        "Agora, escreva uma piada sobre tecnologia."
+    ])
+    
+    # Verifica se o texto gerado está relacionado à descrição da imagem
+    assert isinstance(response.get("text"), str), "A resposta deve conter texto gerado para múltiplos inputs."
+    
+    # Ajustado para verificar se a descrição menciona o fundo azul
+    assert "azul vibrante" in response.get("text"), "Texto gerado deve descrever a imagem com cores."
+    
+    # Verifica se a piada sobre tecnologia foi gerada
+    # Mudamos a verificação para buscar palavras-chave associadas a uma piada de tecnologia
+    assert any(keyword in response.get("text") for keyword in ["vírus", "firewall", "computador", "técnico", "chamas"]), \
+        "Texto gerado deve conter uma piada relacionada à tecnologia."
+def test_generate_invalid_input():
+    """Testa o comportamento do cliente com entradas inválidas, como um tipo não suportado."""
+    client = GeminiClient()
+    with pytest.raises(Exception, match="INVALID_ARGUMENT"):
+        client.generate([{"uri": "invalid_uri", "mime_type": "unknown/type"}])

--- a/testes/test_gemini_client.py
+++ b/testes/test_gemini_client.py
@@ -1,72 +1,45 @@
 #!/usr/bin/env python3
-"""
-Script para testar o cliente Gemini.
+"""Tests for Gemini client.
+
+This module exercises the ``GeminiClient`` when available.  If the
+client cannot be imported (e.g., optional dependency missing), the
+entire test module is skipped.
 """
 
-import os
 import sys
 from pathlib import Path
 
-# Adiciona o diretório 'services' ao path para importar o módulo
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent / "services"))
 
-from gemini_client import GeminiClient
+try:  # pragma: no cover - optional dependency
+    from gemini_client import GeminiClient
+except Exception:  # Module not available, skip tests
+    pytest.skip("gemini_client not available", allow_module_level=True)
 
 
 def test_text_only():
-    """Testa a geração de conteúdo com texto apenas."""
-    print("--- Teste 1: Texto apenas ---")
     client = GeminiClient()
-    try:
-        response = client.generate(["Escreva uma frase criativa sobre inteligência artificial."])
-        print("Resposta:", response["text"])
-        print("Sucesso!\n")
-    except Exception as e:
-        print(f"Erro: {e}\n")
+    response = client.generate(["Escreva uma frase criativa sobre inteligência artificial."])
+    assert isinstance(response.get("text"), str)
 
 
 def test_text_and_image():
-    """Testa a geração de conteúdo com texto e imagem."""
-    print("--- Teste 2: Texto e Imagem ---")
-    # Cria uma imagem de teste simples (quadrado vermelho)
     from PIL import Image
     import io
-    import base64
 
-    # Gera uma imagem simples em memória
-    img = Image.new('RGB', (100, 100), color = 'red')
-    img_byte_arr = io.BytesIO()
-    img.save(img_byte_arr, format='PNG')
-    img_byte_arr = img_byte_arr.getvalue()
+    img = Image.new("RGB", (10, 10), color="red")
+    img_bytes = io.BytesIO()
+    img.save(img_bytes, format="PNG")
+    img_bytes = img_bytes.getvalue()
 
     client = GeminiClient()
-    try:
-        response = client.generate([
-            "O que tem nesta imagem?",
-            img_byte_arr,
-        ])
-        print("Resposta:", response["text"])
-        print("Sucesso!\n")
-    except Exception as e:
-        print(f"Erro: {e}\n")
+    response = client.generate(["O que tem nesta imagem?", img_bytes])
+    assert isinstance(response.get("text"), str)
 
 
 def test_streaming():
-    """Testa a geração de conteúdo em streaming."""
-    print("--- Teste 3: Streaming ---")
     client = GeminiClient()
-    try:
-        print("Gerando conteúdo em streaming...")
-        for chunk in client.generate_stream(["Conte uma história curta sobre um robô aprendendo a cozinhar."]):
-            print(chunk, end="", flush=True)
-        print("\nStreaming finalizado com sucesso!\n")
-    except Exception as e:
-        print(f"Erro: {e}\n")
-
-
-if __name__ == "__main__":
-    print("Iniciando testes do GeminiClient...\n")
-    test_text_only()
-    test_text_and_image()
-    test_streaming()
-    print("Todos os testes concluídos.")
+    chunks = list(client.generate_stream(["Conte uma história curta sobre um robô aprendendo a cozinhar."]))
+    assert chunks  # Should yield at least one chunk

--- a/testes/test_migration_tool.py
+++ b/testes/test_migration_tool.py
@@ -1,0 +1,82 @@
+import os
+import sys
+
+import pytest
+
+# Ensure project root is on sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.migration_tool import WordPressMigrationTool
+
+
+def test_migrate_posts_pipeline(monkeypatch):
+    tool = WordPressMigrationTool(config={"migration": {"dry_run": False}})
+    posts = [
+        {
+            "Slug": "post-1",
+            "ContentHTML": "<p>Hello</p><img src='http://example.com/img.jpg' />",
+            "FeaturedImageUrl": "http://example.com/cover.jpg",
+            "Categories": ["Tech"],
+            "Tags": ["Python", "Testing"],
+            "Permalink": "http://old.example.com/post-1",
+        }
+    ]
+
+    monkeypatch.setattr(
+        "src.migration_tool.get_or_create_author_id",
+        lambda cfg, email, default: "member-1",
+    )
+
+    import_calls = []
+
+    def fake_import_image(cfg, url):
+        import_calls.append(url)
+        return "media-id"
+
+    monkeypatch.setattr(
+        "src.migration_tool.import_image_from_url", fake_import_image
+    )
+
+    def fake_get_terms(cfg, kind, terms):
+        return [f"{kind}-{t}" for t in terms]
+
+    monkeypatch.setattr(
+        "src.migration_tool.get_or_create_terms", fake_get_terms
+    )
+
+    captured = {}
+
+    def fake_create_draft(cfg, post, ricos, *, member_id):
+        captured["ricos"] = ricos
+        return {"draftPost": {"id": "draft-1"}}
+
+    monkeypatch.setattr(
+        "src.migration_tool.create_draft_post", fake_create_draft
+    )
+
+    publish_info = {}
+
+    def fake_publish(cfg, draft_id):
+        publish_info["draft_id"] = draft_id
+        return {"post": {"url": f"https://new.example.com/post/{posts[0]['Slug']}"}}
+
+    monkeypatch.setattr(
+        "src.migration_tool.publish_post", fake_publish
+    )
+
+    tool.migrate_posts(posts, new_base_url="https://new.example.com")
+
+    assert posts[0]["FeaturedImageId"] == "media-id"
+    assert posts[0]["CategoryIds"] == ["categories-Tech"]
+    assert posts[0]["TagIds"] == ["tags-Python", "tags-Testing"]
+    assert len(import_calls) == 2
+
+    ricos = captured.get("ricos")
+    assert ricos is not None and "nodes" in ricos
+    assert any(
+        node.get("type") == "IMAGE" and
+        node.get("imageData", {}).get("image", {}).get("src", {}).get("id") == "media-id"
+        for node in ricos["nodes"]
+    )
+
+    assert publish_info["draft_id"] == "draft-1"


### PR DESCRIPTION
## Summary
- ensure WixPost slug is generated from title when missing
- add migration tool test mocking external dependencies to verify image import, taxonomy resolution and rich-content generation
- skip Gemini client tests when optional dependency is unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad1c663b548329b32d0e928fbc073d