### PR TITLE
refactor(tool): route debug output through log_message

### DIFF
--- a/src/migration_tool.py
+++ b/src/migration_tool.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from src.extractors.wordpress_extractor import extract_posts_from_csv, extract_posts_from_xml
 from src.parsers.ricos_parser import convert_html_to_ricos
@@ -134,11 +134,8 @@ class WordPressMigrationTool:
             slug = post.get("Slug") or ""
             self.log_message(f"Migrating post '{slug}'")
 
-            # Print HTML content for debugging
-            print(f"DEBUG: Post '{slug}' HTML content:")
-            print(post.get("ContentHTML", ""))
-            print("---")
-
+            # Log HTML content for debugging
+            self.log_message(f"Post '{slug}' HTML content:\n{post.get('ContentHTML', '')}", level="DEBUG")
             author_email = post.get("Author Email")
             member_id = None
             default_author_email = "default-author@example.com" # Define a default email
@@ -200,7 +197,7 @@ class WordPressMigrationTool:
 
                 
                 # HTML conversion
-                print(f"DEBUG: Converting HTML to Ricos for post '{slug}'")
+                self.log_message(f"Converting HTML to Ricos for post '{slug}'", level="DEBUG")
                 image_importer = lambda url: import_image_from_url(self.config["wix"], url)
                 ricos = convert_html_to_ricos(
                     post.get("ContentHTML", ""), 
@@ -208,10 +205,7 @@ class WordPressMigrationTool:
                     image_importer=image_importer if not dry_run else None,
                     paragraph_spacing_px=2
                 )
-                print(f"DEBUG: Ricos content for post '{slug}':")
-                print(ricos)
-                print("---")
-                
+                self.log_message(f"Ricos content for post '{slug}':\n{ricos}", level="DEBUG")
                 # Create draft
                 if dry_run:
                     self.log_message(f"Dry-run: would create draft for {slug}")


### PR DESCRIPTION
## Summary
- log raw HTML with `log_message` instead of printing
- capture Ricos conversion details via debug logging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gemini_client')*
- `cat reports/migration/migration.log`


------
https://chatgpt.com/codex/tasks/task_e_68ad1c68c12883299700521da8bba045